### PR TITLE
Optimize Dockerfile to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,9 @@ RUN apt-get update \
       wkhtmltopdf \
       texlive \
       build-essential python3-dev python3-pip python3-setuptools python3-wheel python3-cffi libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 libffi-dev shared-mime-info \
+ && rm -rf /var/lib/apt/lists/* \
  # https://stackoverflow.com/questions/75608323/how-do-i-solve-error-externally-managed-environment-every-time-i-use-pip-3
- && pip3 install --break-system-packages weasyprint \
+ && pip3 install --no-cache-dir --break-system-packages weasyprint \
  && pandoc --version
 
 COPY --from=builder /usr/local/cargo/bin/md-to-pdf /usr/local/bin/md-to-pdf


### PR DESCRIPTION
Implement best practices for package management to minimize unnecessary data in Docker image. Remove APT cache after installation and prevent pip from creating cache files. These changes result in a smaller and more efficient Docker image.